### PR TITLE
fix empty item image

### DIFF
--- a/src/Provider/LineItemImagesProvider.php
+++ b/src/Provider/LineItemImagesProvider.php
@@ -60,7 +60,16 @@ final class LineItemImagesProvider implements LineItemImagesProviderInterface
 
     private function getUrlFromPath(string $path): string
     {
-        $url = $this->filterExtension->filter($path, $this->filterName);
+        // if given path is empty, InvalidParameterException will be thrown in filter action
+        if (empty($path)) {
+            return $this->fallbackImage;
+        }
+
+        try {
+            $url = $this->filterExtension->filter($path, $this->filterName);
+        } catch (\Exception $e) {
+            return $this->fallbackImage;
+        }
 
         // Localhost images are not displayed by Stripe because it cache it on a CDN
         if (0 !== preg_match('#//localhost#', $url)) {

--- a/src/Provider/LineItemImagesProvider.php
+++ b/src/Provider/LineItemImagesProvider.php
@@ -40,7 +40,7 @@ final class LineItemImagesProvider implements LineItemImagesProviderInterface
         }
 
         $imageUrl = $this->getImageUrlFromProduct($product);
-        if (!$imageUrl) {
+        if ($imageUrl === "") {
             return [];
         }
 
@@ -66,7 +66,7 @@ final class LineItemImagesProvider implements LineItemImagesProviderInterface
     private function getUrlFromPath(string $path): string
     {
         // if given path is empty, InvalidParameterException will be thrown in filter action
-        if (empty($path)) {
+        if ($path === "") {
             return $this->fallbackImage;
         }
 

--- a/src/Provider/LineItemImagesProvider.php
+++ b/src/Provider/LineItemImagesProvider.php
@@ -39,8 +39,13 @@ final class LineItemImagesProvider implements LineItemImagesProviderInterface
             return [];
         }
 
+        $imageUrl = $this->getImageUrlFromProduct($product);
+        if (!$imageUrl) {
+            return [];
+        }
+
         return [
-            $this->getImageUrlFromProduct($product),
+            $imageUrl,
         ];
     }
 


### PR DESCRIPTION
* When product don't have main image path, `filterExtension->filter` throws an InvalidParameterException
  1. check if `$path` is empty then return the `fallbackImage`
  2. catch any other exception to avoid future 500 at this step
* When fallback image is not provided, Stripe API respond with an `InvalidRequestException` (see message bellow)
  1. then, assume `getImageUrlFromProduct` return a non empty string.
  2. else : return an empty image array

InvalidRequestException message is (assuming item without image is the third one) :

```
You passed an empty string for 'line_items[2][images][0]'. We assume empty values are an attempt to unset a parameter; however 'line_items[2][images][0]' cannot be unset. You should remove 'line_items[2][images][0]' from your request or supply a non-empty value.
``` 