### PR TITLE
Improve documentation when not using the flex recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Enable this plugin :
 
 return [
     // ...
-    FluxSE\SyliusPayumStripePlugin\FluxSESyliusPayumStripePlugin::class => ['all' => true],
+    FluxSE\SyliusPayumStripePlugin\FluxSESyliusPayumStripePlugin::class => ['all' => true],    
+    FluxSE\PayumStripeBundle\FluxSEPayumStripeBundle::class => ['all' => true],
     // ...
 ];
 ```


### PR DESCRIPTION
A bundle is missing the documentation for `bundles.php` when not using the flex recipes.

We should the  FluxSE\PayumStripeBundle\FluxSEPayumStripeBundle::class => ['all' => true], otherwise the gateway factory will not be created and the error "Gateway "stripe_checkout_session" does not exist" occurs.
