### PR TITLE
Add payment intent cancelation when new payment intent is done for the same order

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -18,9 +18,4 @@ return static function (ContainerConfigurator $containerConfigurator): void {
      * in vendor/friendsofphp/php-cs-fixer/src/AbstractFixer.php on line 155
      */
     $services->set(BinaryOperatorSpacesFixer::class);
-
-    /**
-     * Miss configured fixer into sylius-labs/coding-standard v4.1.0
-     */
-    $services->set(ClassAttributesSeparationFixer::class);
 };

--- a/spec/Action/ConvertPaymentActionSpec.php
+++ b/spec/Action/ConvertPaymentActionSpec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace spec\FluxSE\SyliusPayumStripePlugin\Action;
 
 use FluxSE\SyliusPayumStripePlugin\Action\ConvertPaymentAction;
+use FluxSE\SyliusPayumStripePlugin\Action\ConvertPaymentActionInterface;
 use FluxSE\SyliusPayumStripePlugin\Provider\DetailsProviderInterface;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\Request\Convert;
@@ -31,6 +32,7 @@ final class ConvertPaymentActionSpec extends ObjectBehavior
     public function it_implements_action_interface(): void
     {
         $this->shouldHaveType(ActionInterface::class);
+        $this->shouldHaveType(ConvertPaymentActionInterface::class);
     }
 
     /**

--- a/spec/Extension/CancelExistingPaymentIntentExtensionSpec.php
+++ b/spec/Extension/CancelExistingPaymentIntentExtensionSpec.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\FluxSE\SyliusPayumStripePlugin\Extension;
+
+use FluxSE\PayumStripe\Request\Api\Resource\CustomCallInterface;
+use FluxSE\SyliusPayumStripePlugin\Action\ConvertPaymentActionInterface;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Extension\Context;
+use Payum\Core\Extension\ExtensionInterface;
+use Payum\Core\GatewayInterface;
+use Payum\Core\Request\Convert;
+use PhpSpec\ObjectBehavior;
+use Stripe\PaymentIntent;
+use FluxSE\SyliusPayumStripePlugin\Factory\CancelPaymentIntentRequestFactoryInterface;
+use Stripe\SetupIntent;
+use Sylius\Component\Core\Model\PaymentInterface;
+
+final class CancelExistingPaymentIntentExtensionSpec extends ObjectBehavior
+{
+    public function let(
+        CancelPaymentIntentRequestFactoryInterface $cancelPaymentIntentRequestFactory
+    ): void {
+        $this->beConstructedWith($cancelPaymentIntentRequestFactory);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldBeAnInstanceOf(ExtensionInterface::class);
+    }
+
+    public function it_do_nothing_when_action_is_not_the_convert_payment_action_targeted(
+        Context $context,
+        ActionInterface $action
+    ):void {
+        $context->getAction()->willReturn($action);
+
+        $this->onExecute($context);
+    }
+
+    public function it_do_nothing_when_payment_details_are_empty(
+        Context $context,
+        ConvertPaymentActionInterface $action,
+        Convert $request,
+        PaymentInterface $payment
+    ):void {
+        $context->getAction()->willReturn($action);
+        $context->getRequest()->willReturn($request);
+        $request->getSource()->willReturn($payment);
+
+        $payment->getDetails()->willReturn([]);
+
+        $this->onExecute($context);
+    }
+
+    public function it_do_nothing_when_payment_details_are_something_else_than_a_payment_intent(
+        Context $context,
+        ConvertPaymentActionInterface $action,
+        Convert $request,
+        PaymentInterface $payment
+    ):void {
+        $context->getAction()->willReturn($action);
+        $context->getRequest()->willReturn($request);
+        $request->getSource()->willReturn($payment);
+
+        $payment->getDetails()->willReturn([
+            'object' => SetupIntent::OBJECT_NAME,
+        ]);
+
+        $this->onExecute($context);
+    }
+
+    public function it_found_a_previous_payment_intent_and_cancel_it(
+        Context $context,
+        ConvertPaymentActionInterface $action,
+        Convert $request,
+        PaymentInterface $payment,
+        GatewayInterface $gateway,
+        CancelPaymentIntentRequestFactoryInterface $cancelPaymentIntentRequestFactory,
+        CustomCallInterface $cancelPaymentIntentRequest
+    ): void {
+        $context->getAction()->willReturn($action);
+        $context->getRequest()->willReturn($request);
+        $request->getSource()->willReturn($payment);
+        $context->getGateway()->willReturn($gateway);
+
+        $piId = 'pi_test_0000000000000000000';
+        $payment->getDetails()->willReturn([
+            'id' => $piId,
+            'object' => PaymentIntent::OBJECT_NAME,
+        ]);
+
+        $cancelPaymentIntentRequest->beConstructedWith([$piId]);
+
+        $cancelPaymentIntentRequestFactory
+            ->createNew($piId)
+            ->willReturn($cancelPaymentIntentRequest);
+
+        $gateway->execute($cancelPaymentIntentRequest)->shouldBeCalled();
+
+        $this->onExecute($context);
+    }
+
+    public function it_onPreExecute_does_nothing(Context $context): void
+    {
+        $this->onPreExecute($context);
+    }
+
+    public function it_onPostExecute_does_nothing(Context $context): void
+    {
+        $this->onPostExecute($context);
+    }
+}

--- a/spec/Extension/UpdatePaymentStateExtensionSpec.php
+++ b/spec/Extension/UpdatePaymentStateExtensionSpec.php
@@ -20,7 +20,7 @@ use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Payment\PaymentTransitions;
 use Sylius\Component\Resource\StateMachine\StateMachineInterface;
 
-class UpdatePaymentStateExtensionSpec extends ObjectBehavior
+final class UpdatePaymentStateExtensionSpec extends ObjectBehavior
 {
     public function let(
         FactoryInterface $factory,

--- a/spec/Extension/UpdatePaymentStateExtensionSpec.php
+++ b/spec/Extension/UpdatePaymentStateExtensionSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\FluxSE\SyliusPayumStripePlugin\Extension;
 
 use Payum\Core\Extension\Context;

--- a/spec/Provider/CustomerEmailProviderSpec.php
+++ b/spec/Provider/CustomerEmailProviderSpec.php
@@ -10,7 +10,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 
-class CustomerEmailProviderSpec extends ObjectBehavior
+final class CustomerEmailProviderSpec extends ObjectBehavior
 {
     public function it_is_initializable(): void
     {

--- a/spec/Provider/DetailsProviderSpec.php
+++ b/spec/Provider/DetailsProviderSpec.php
@@ -12,7 +12,7 @@ use FluxSE\SyliusPayumStripePlugin\Provider\PaymentMethodTypesProviderInterface;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 
-class DetailsProviderSpec extends ObjectBehavior
+final class DetailsProviderSpec extends ObjectBehavior
 {
     public function let(
         CustomerEmailProviderInterface $customerEmailProvider,

--- a/spec/Provider/LineItemImagesProviderSpec.php
+++ b/spec/Provider/LineItemImagesProviderSpec.php
@@ -13,7 +13,7 @@ use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\ProductImageInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 
-class LineItemImagesProviderSpec extends ObjectBehavior
+final class LineItemImagesProviderSpec extends ObjectBehavior
 {
     public function let(FilterExtension $filterExtension): void
     {

--- a/spec/Provider/LineItemProviderSpec.php
+++ b/spec/Provider/LineItemProviderSpec.php
@@ -12,7 +12,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 
-class LineItemProviderSpec extends ObjectBehavior
+final class LineItemProviderSpec extends ObjectBehavior
 {
     public function let(
         LineItemImagesProviderInterface $lineItemImagesProvider,

--- a/spec/Provider/LineItemsProviderSpec.php
+++ b/spec/Provider/LineItemsProviderSpec.php
@@ -13,7 +13,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 
-class LineItemsProviderSpec extends ObjectBehavior
+final class LineItemsProviderSpec extends ObjectBehavior
 {
     public function let(
         LineItemProviderInterface $lineItemProvider,

--- a/spec/Provider/LinetItemNameProviderSpec.php
+++ b/spec/Provider/LinetItemNameProviderSpec.php
@@ -10,7 +10,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 
-class LinetItemNameProviderSpec extends ObjectBehavior
+final class LinetItemNameProviderSpec extends ObjectBehavior
 {
     public function it_is_initializable(): void
     {

--- a/spec/Provider/PaymentMethodTypesProviderSpec.php
+++ b/spec/Provider/PaymentMethodTypesProviderSpec.php
@@ -9,7 +9,7 @@ use FluxSE\SyliusPayumStripePlugin\Provider\PaymentMethodTypesProviderInterface;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 
-class PaymentMethodTypesProviderSpec extends ObjectBehavior
+final class PaymentMethodTypesProviderSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/spec/Provider/ShippingLineItemNameProviderSpec.php
+++ b/spec/Provider/ShippingLineItemNameProviderSpec.php
@@ -12,7 +12,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Model\ShippingMethodInterface;
 
-class ShippingLineItemNameProviderSpec extends ObjectBehavior
+final class ShippingLineItemNameProviderSpec extends ObjectBehavior
 {
     public function it_is_initializable(): void
     {

--- a/spec/Provider/ShippingLineItemProviderSpec.php
+++ b/spec/Provider/ShippingLineItemProviderSpec.php
@@ -10,7 +10,7 @@ use FluxSE\SyliusPayumStripePlugin\Provider\ShippingLineItemProviderInterface;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 
-class ShippingLineItemProviderSpec extends ObjectBehavior
+final class ShippingLineItemProviderSpec extends ObjectBehavior
 {
     public function let(
         ShippingLineItemNameProviderInterface $shippingLineItemNameProvider

--- a/spec/StateMachine/CancelAuthorizedOrderProcessorSpec.php
+++ b/spec/StateMachine/CancelAuthorizedOrderProcessorSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\FluxSE\SyliusPayumStripePlugin\StateMachine;
 
 use FluxSE\SyliusPayumStripePlugin\Factory\CancelRequestFactoryInterface;
@@ -33,12 +35,11 @@ class CancelAuthorizedOrderProcessorSpec extends ObjectBehavior
         CancelRequestFactoryInterface $cancelRequestFactory,
         ModelAggregateInterface $request
     ): void {
-
         $payment->getState()->willReturn(PaymentInterface::STATE_AUTHORIZED);
 
         $payment->getMethod()->willReturn($paymentMethod);
         $paymentMethod->getGatewayConfig()->willReturn($gatewayConfig);
-        $gatewayConfig->getConfig()->willReturn(['factory'=>'stripe_checkout_session']);
+        $gatewayConfig->getConfig()->willReturn(['factory' => 'stripe_checkout_session']);
         $gatewayName = 'stripe_checkout_session_with_sca';
         $gatewayConfig->getGatewayName()->willReturn($gatewayName);
 
@@ -57,7 +58,7 @@ class CancelAuthorizedOrderProcessorSpec extends ObjectBehavior
 
     public function it_do_nothing_when_it_is_not_an_authorized_state(
         PaymentInterface $payment
-    ):void {
+    ): void {
         $payment->getState()->willReturn(PaymentInterface::STATE_COMPLETED);
 
         $this->__invoke($payment);

--- a/spec/StateMachine/CancelAuthorizedOrderProcessorSpec.php
+++ b/spec/StateMachine/CancelAuthorizedOrderProcessorSpec.php
@@ -15,7 +15,7 @@ use Sylius\Bundle\PayumBundle\Model\GatewayConfigInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 
-class CancelAuthorizedOrderProcessorSpec extends ObjectBehavior
+final class CancelAuthorizedOrderProcessorSpec extends ObjectBehavior
 {
     public function let(
         CancelRequestFactoryInterface $cancelRequestFactory,

--- a/spec/StateMachine/CompleteAuthorizedOrderProcessorSpec.php
+++ b/spec/StateMachine/CompleteAuthorizedOrderProcessorSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\FluxSE\SyliusPayumStripePlugin\StateMachine;
 
 use FluxSE\SyliusPayumStripePlugin\Factory\CaptureRequestFactoryInterface;
@@ -33,12 +35,11 @@ class CompleteAuthorizedOrderProcessorSpec extends ObjectBehavior
         CaptureRequestFactoryInterface $captureRequestFactory,
         ModelAggregateInterface $request
     ): void {
-
         $payment->getState()->willReturn(PaymentInterface::STATE_AUTHORIZED);
 
         $payment->getMethod()->willReturn($paymentMethod);
         $paymentMethod->getGatewayConfig()->willReturn($gatewayConfig);
-        $gatewayConfig->getConfig()->willReturn(['factory'=>'stripe_checkout_session']);
+        $gatewayConfig->getConfig()->willReturn(['factory' => 'stripe_checkout_session']);
         $gatewayName = 'stripe_checkout_session_with_sca';
         $gatewayConfig->getGatewayName()->willReturn($gatewayName);
 
@@ -57,7 +58,7 @@ class CompleteAuthorizedOrderProcessorSpec extends ObjectBehavior
 
     public function it_do_nothing_when_it_is_not_an_authorized_state(
         PaymentInterface $payment
-    ):void {
+    ): void {
         $payment->getState()->willReturn(PaymentInterface::STATE_COMPLETED);
 
         $this->__invoke($payment);

--- a/spec/StateMachine/CompleteAuthorizedOrderProcessorSpec.php
+++ b/spec/StateMachine/CompleteAuthorizedOrderProcessorSpec.php
@@ -15,7 +15,7 @@ use Sylius\Bundle\PayumBundle\Model\GatewayConfigInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 
-class CompleteAuthorizedOrderProcessorSpec extends ObjectBehavior
+final class CompleteAuthorizedOrderProcessorSpec extends ObjectBehavior
 {
     public function let(
         CaptureRequestFactoryInterface $captureRequestFactory,

--- a/spec/StateMachine/RefundOrderProcessorSpec.php
+++ b/spec/StateMachine/RefundOrderProcessorSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\FluxSE\SyliusPayumStripePlugin\StateMachine;
 
 use FluxSE\SyliusPayumStripePlugin\Factory\RefundRequestFactoryInterface;
@@ -33,12 +35,11 @@ class RefundOrderProcessorSpec extends ObjectBehavior
         RefundRequestFactoryInterface $refundRequestFactory,
         ModelAggregateInterface $request
     ): void {
-
         $payment->getState()->willReturn(PaymentInterface::STATE_COMPLETED);
 
         $payment->getMethod()->willReturn($paymentMethod);
         $paymentMethod->getGatewayConfig()->willReturn($gatewayConfig);
-        $gatewayConfig->getConfig()->willReturn(['factory'=>'stripe_checkout_session']);
+        $gatewayConfig->getConfig()->willReturn(['factory' => 'stripe_checkout_session']);
         $gatewayName = 'stripe_checkout_session_with_sca';
         $gatewayConfig->getGatewayName()->willReturn($gatewayName);
 
@@ -57,7 +58,7 @@ class RefundOrderProcessorSpec extends ObjectBehavior
 
     public function it_do_nothing_when_it_is_not_a_completed_state(
         PaymentInterface $payment
-    ):void {
+    ): void {
         $payment->getState()->willReturn(PaymentInterface::STATE_AUTHORIZED);
 
         $this->__invoke($payment);

--- a/spec/StateMachine/RefundOrderProcessorSpec.php
+++ b/spec/StateMachine/RefundOrderProcessorSpec.php
@@ -15,7 +15,7 @@ use Sylius\Bundle\PayumBundle\Model\GatewayConfigInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 
-class RefundOrderProcessorSpec extends ObjectBehavior
+final class RefundOrderProcessorSpec extends ObjectBehavior
 {
     public function let(
         RefundRequestFactoryInterface $refundRequestFactory,

--- a/src/Action/ConvertPaymentAction.php
+++ b/src/Action/ConvertPaymentAction.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace FluxSE\SyliusPayumStripePlugin\Action;
 
 use FluxSE\SyliusPayumStripePlugin\Provider\DetailsProviderInterface;
-use Payum\Core\Action\ActionInterface;
 use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\Convert;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 
-final class ConvertPaymentAction implements ActionInterface
+final class ConvertPaymentAction implements ConvertPaymentActionInterface
 {
     /** @var DetailsProviderInterface */
     private $detailsProvider;

--- a/src/Action/ConvertPaymentActionInterface.php
+++ b/src/Action/ConvertPaymentActionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusPayumStripePlugin\Action;
+
+use Payum\Core\Action\ActionInterface;
+
+interface ConvertPaymentActionInterface extends ActionInterface
+{
+}

--- a/src/DependencyInjection/Compiler/PayumStoragePaymentAliaser.php
+++ b/src/DependencyInjection/Compiler/PayumStoragePaymentAliaser.php
@@ -14,7 +14,7 @@ final class PayumStoragePaymentAliaser implements CompilerPassInterface
     {
         $paymentClass = $container->getParameter('sylius.model.payment.class');
         $serviceIds = $container->findTaggedServiceIds('payum.storage');
-        /** @var string $serviceId */
+
         foreach (array_keys($serviceIds) as $serviceId) {
             $serviceDefinition = $container->findDefinition($serviceId);
             $modelClass = $this->findModelClassAttribute($serviceDefinition);

--- a/src/Extension/CancelExistingPaymentIntentExtension.php
+++ b/src/Extension/CancelExistingPaymentIntentExtension.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusPayumStripePlugin\Extension;
+
+use FluxSE\SyliusPayumStripePlugin\Action\ConvertPaymentActionInterface;
+use FluxSE\SyliusPayumStripePlugin\Factory\CancelPaymentIntentRequestFactoryInterface;
+use Payum\Core\Extension\Context;
+use Payum\Core\Extension\ExtensionInterface;
+use Payum\Core\Request\Convert;
+use Stripe\PaymentIntent;
+use Sylius\Component\Core\Model\PaymentInterface;
+
+/**
+ * This extension will cancel a PaymentIntent if there is an existant one
+ * inside the payment details
+ */
+final class CancelExistingPaymentIntentExtension implements ExtensionInterface
+{
+    /** @var CancelPaymentIntentRequestFactoryInterface */
+    private $cancelPaymentIntentRequestFactory;
+
+    public function __construct(CancelPaymentIntentRequestFactoryInterface $cancelPaymentIntentRequestFactory)
+    {
+        $this->cancelPaymentIntentRequestFactory = $cancelPaymentIntentRequestFactory;
+    }
+
+    public function onPreExecute(Context $context): void
+    {
+    }
+
+    public function onExecute(Context $context): void
+    {
+        $action = $context->getAction();
+
+        if (false === $action instanceof ConvertPaymentActionInterface) {
+            return;
+        }
+
+        $request = $context->getRequest();
+        if (false === $request instanceof Convert) {
+            return;
+        }
+
+        $payment = $request->getSource();
+        if (false === $payment instanceof PaymentInterface) {
+            return;
+        }
+
+        $details = $payment->getDetails();
+        /** @var string|null $object */
+        $object = $details['object'] ?? null;
+        if (PaymentIntent::OBJECT_NAME !== $object) {
+            return;
+        }
+
+        /** @var string|null $id */
+        $id = $details['id'] ?? null;
+        if (null === $id) {
+            return;
+        }
+
+        $gateway = $context->getGateway();
+        $cancelPaymentIntentRequest = $this->cancelPaymentIntentRequestFactory->createNew($id);
+        $gateway->execute($cancelPaymentIntentRequest);
+    }
+
+    public function onPostExecute(Context $context): void
+    {
+    }
+}

--- a/src/Factory/CancelPaymentIntentRequestFactory.php
+++ b/src/Factory/CancelPaymentIntentRequestFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusPayumStripePlugin\Factory;
+
+use FluxSE\PayumStripe\Request\Api\Resource\CancelPaymentIntent;
+use FluxSE\PayumStripe\Request\Api\Resource\CustomCallInterface;
+
+final class CancelPaymentIntentRequestFactory implements CancelPaymentIntentRequestFactoryInterface
+{
+    public function createNew(string $id): CustomCallInterface
+    {
+        return new CancelPaymentIntent($id);
+    }
+}

--- a/src/Factory/CancelPaymentIntentRequestFactoryInterface.php
+++ b/src/Factory/CancelPaymentIntentRequestFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusPayumStripePlugin\Factory;
+
+use FluxSE\PayumStripe\Request\Api\Resource\CustomCallInterface;
+
+interface CancelPaymentIntentRequestFactoryInterface
+{
+    public function createNew(string $id): CustomCallInterface;
+}

--- a/src/Resources/config/services/factory.yaml
+++ b/src/Resources/config/services/factory.yaml
@@ -8,3 +8,6 @@ services:
 
   flux_se.sylius_payum_stripe.factory.capture_request:
     class: FluxSE\SyliusPayumStripePlugin\Factory\CaptureRequestFactory
+
+  flux_se.sylius_payum_stripe.factory.cancel_payment_intent_request:
+    class: FluxSE\SyliusPayumStripePlugin\Factory\CancelPaymentIntentRequestFactory

--- a/src/Resources/config/services/payum.yaml
+++ b/src/Resources/config/services/payum.yaml
@@ -24,3 +24,13 @@ services:
       - name: payum.extension
         factory: stripe_checkout_session
         alias: flux_se.sylius_payum_stripe.extension.update_payment_state
+
+  flux_se.sylius_payum_stripe.extension.cancel_existing_payment_intent:
+    public: true
+    class: FluxSE\SyliusPayumStripePlugin\Extension\CancelExistingPaymentIntentExtension
+    arguments:
+      $cancelPaymentIntentRequestFactory: '@flux_se.sylius_payum_stripe.factory.cancel_payment_intent_request'
+    tags:
+      - name: payum.extension
+        factory: stripe_checkout_session
+        alias: flux_se.sylius_payum_stripe.extension.cancel_existing_payment_intent

--- a/tests/Application/config/symfony/5.4/services.yaml
+++ b/tests/Application/config/symfony/5.4/services.yaml
@@ -1,0 +1,4 @@
+services:
+  # Bug while Sf 5.4 was launched but Sylius was still using the old service name
+  security.authentication_manager:
+    alias: security.authentication.manager


### PR DESCRIPTION
This PR will fix a specific behaviour while an order has already start a Stripe Checkout Session and start another one.

Right now if the first Checkout Session is completed it won't make the order paid because the second Checkout Session overwrite the first `Payment->getDetails()`.

Now the `PaymentIntent` will be canceled when the second Checkout Session will be started, making the first Checkout Session expire (if the customer try to pay, a message will be displayed telling the session expired).
This is done inside an extension during the `Convert` by detecting if there is a `PaymentIntent` inside the `Payment->getDetails()` and cancel it before continuing to overwrite it.