### PR TITLE
Expire session instead of cancel payment intent

### DIFF
--- a/spec/Extension/CancelExistingPaymentIntentExtensionSpec.php
+++ b/spec/Extension/CancelExistingPaymentIntentExtensionSpec.php
@@ -4,15 +4,19 @@ declare(strict_types=1);
 
 namespace spec\FluxSE\SyliusPayumStripePlugin\Extension;
 
+use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\CustomCallInterface;
 use FluxSE\SyliusPayumStripePlugin\Action\ConvertPaymentActionInterface;
-use FluxSE\SyliusPayumStripePlugin\Factory\CancelPaymentIntentRequestFactoryInterface;
+use FluxSE\SyliusPayumStripePlugin\Factory\AllSessionRequestFactoryInterface;
+use FluxSE\SyliusPayumStripePlugin\Factory\ExpireSessionRequestFactoryInterface;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\Extension\Context;
 use Payum\Core\Extension\ExtensionInterface;
 use Payum\Core\GatewayInterface;
 use Payum\Core\Request\Convert;
 use PhpSpec\ObjectBehavior;
+use Stripe\Checkout\Session;
+use Stripe\Collection;
 use Stripe\PaymentIntent;
 use Stripe\SetupIntent;
 use Sylius\Component\Core\Model\PaymentInterface;
@@ -20,9 +24,13 @@ use Sylius\Component\Core\Model\PaymentInterface;
 final class CancelExistingPaymentIntentExtensionSpec extends ObjectBehavior
 {
     public function let(
-        CancelPaymentIntentRequestFactoryInterface $cancelPaymentIntentRequestFactory
+        ExpireSessionRequestFactoryInterface $expireSessionRequestFactory,
+        AllSessionRequestFactoryInterface $allSessionRequestFactory
     ): void {
-        $this->beConstructedWith($cancelPaymentIntentRequestFactory);
+        $this->beConstructedWith(
+            $expireSessionRequestFactory,
+            $allSessionRequestFactory
+        );
     }
 
     public function it_is_initializable(): void
@@ -30,7 +38,7 @@ final class CancelExistingPaymentIntentExtensionSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf(ExtensionInterface::class);
     }
 
-    public function it_do_nothing_when_action_is_not_the_convert_payment_action_targeted(
+    public function it_does_nothing_when_action_is_not_the_convert_payment_action_targeted(
         Context $context,
         ActionInterface $action
     ): void {
@@ -39,7 +47,7 @@ final class CancelExistingPaymentIntentExtensionSpec extends ObjectBehavior
         $this->onExecute($context);
     }
 
-    public function it_do_nothing_when_payment_details_are_empty(
+    public function it_does_nothing_when_payment_details_are_empty(
         Context $context,
         ConvertPaymentActionInterface $action,
         Convert $request,
@@ -54,7 +62,7 @@ final class CancelExistingPaymentIntentExtensionSpec extends ObjectBehavior
         $this->onExecute($context);
     }
 
-    public function it_do_nothing_when_payment_details_are_something_else_than_a_payment_intent(
+    public function it_does_nothing_when_payment_details_are_something_else_than_a_payment_intent(
         Context $context,
         ConvertPaymentActionInterface $action,
         Convert $request,
@@ -71,14 +79,14 @@ final class CancelExistingPaymentIntentExtensionSpec extends ObjectBehavior
         $this->onExecute($context);
     }
 
-    public function it_found_a_previous_payment_intent_and_cancel_it(
+    public function it_doesnt_found_the_related_session_and_do_nothing(
         Context $context,
         ConvertPaymentActionInterface $action,
         Convert $request,
         PaymentInterface $payment,
         GatewayInterface $gateway,
-        CancelPaymentIntentRequestFactoryInterface $cancelPaymentIntentRequestFactory,
-        CustomCallInterface $cancelPaymentIntentRequest
+        AllSessionRequestFactoryInterface $allSessionRequestFactory,
+        AllInterface $allSessionRequest
     ): void {
         $context->getAction()->willReturn($action);
         $context->getRequest()->willReturn($request);
@@ -91,13 +99,110 @@ final class CancelExistingPaymentIntentExtensionSpec extends ObjectBehavior
             'object' => PaymentIntent::OBJECT_NAME,
         ]);
 
-        $cancelPaymentIntentRequest->beConstructedWith([$piId]);
+        $allSessionRequestFactory
+            ->createNew()
+            ->willReturn($allSessionRequest);
 
-        $cancelPaymentIntentRequestFactory
-            ->createNew($piId)
-            ->willReturn($cancelPaymentIntentRequest);
+        $allSessionRequest->setParameters([
+            'payment_intent' => $piId
+        ])->shouldBeCalled();
+        $allSessionRequest->getApiResources()->willReturn(Collection::constructFrom(['data'=>[]]));
 
-        $gateway->execute($cancelPaymentIntentRequest)->shouldBeCalled();
+        $gateway->execute($allSessionRequest)->shouldBeCalled();
+
+        $this->onExecute($context);
+    }
+
+    public function it_founds_a_related_expired_session_and_does_nothing(
+        Context $context,
+        ConvertPaymentActionInterface $action,
+        Convert $request,
+        PaymentInterface $payment,
+        GatewayInterface $gateway,
+        AllSessionRequestFactoryInterface $allSessionRequestFactory,
+        AllInterface $allSessionRequest
+    ): void {
+        $context->getAction()->willReturn($action);
+        $context->getRequest()->willReturn($request);
+        $request->getSource()->willReturn($payment);
+        $context->getGateway()->willReturn($gateway);
+
+        $piId = 'pi_test_0000000000000000000';
+        $csId = 'cs_test_0000000000000000000';
+        $payment->getDetails()->willReturn([
+            'id' => $piId,
+            'object' => PaymentIntent::OBJECT_NAME,
+        ]);
+
+        $allSessionRequestFactory
+            ->createNew()
+            ->willReturn($allSessionRequest);
+
+        $allSessionRequest->setParameters([
+            'payment_intent' => $piId
+        ])->shouldBeCalled();
+        $allSessionRequest->getApiResources()->willReturn(Collection::constructFrom([
+            'data'=>[
+                [
+                    'id' => $csId,
+                    'status' => Session::STATUS_EXPIRED,
+                ]
+            ]
+        ]));
+
+        $gateway->execute($allSessionRequest)->shouldBeCalled();
+
+        $this->onExecute($context);
+    }
+
+    public function it_founds_a_related_session_and_expires_it(
+        Context $context,
+        ConvertPaymentActionInterface $action,
+        Convert $request,
+        PaymentInterface $payment,
+        GatewayInterface $gateway,
+        AllSessionRequestFactoryInterface $allSessionRequestFactory,
+        AllInterface $allSessionRequest,
+        ExpireSessionRequestFactoryInterface $expireSessionRequestFactory,
+        CustomCallInterface $expireSessionRequest
+    ): void {
+        $context->getAction()->willReturn($action);
+        $context->getRequest()->willReturn($request);
+        $request->getSource()->willReturn($payment);
+        $context->getGateway()->willReturn($gateway);
+
+        $piId = 'pi_test_0000000000000000000';
+        $csId = 'cs_test_0000000000000000000';
+        $payment->getDetails()->willReturn([
+            'id' => $piId,
+            'object' => PaymentIntent::OBJECT_NAME,
+        ]);
+
+        $allSessionRequestFactory
+            ->createNew()
+            ->willReturn($allSessionRequest);
+
+        $allSessionRequest->setParameters([
+            'payment_intent' => $piId
+        ])->shouldBeCalled();
+        $allSessionRequest->getApiResources()->willReturn(Collection::constructFrom([
+            'data'=>[
+                [
+                    'id' => $csId,
+                    'status' => Session::STATUS_OPEN,
+                ]
+            ]
+        ]));
+
+        $gateway->execute($allSessionRequest)->shouldBeCalled();
+
+        $expireSessionRequest->beConstructedWith([$csId]);
+
+        $expireSessionRequestFactory
+            ->createNew($csId)
+            ->willReturn($expireSessionRequest);
+
+        $gateway->execute($expireSessionRequest)->shouldBeCalled();
 
         $this->onExecute($context);
     }

--- a/src/Factory/AllSessionRequestFactory.php
+++ b/src/Factory/AllSessionRequestFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusPayumStripePlugin\Factory;
+
+use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
+use FluxSE\PayumStripe\Request\Api\Resource\AllSession;
+
+final class AllSessionRequestFactory implements AllSessionRequestFactoryInterface
+{
+    public function createNew(): AllInterface
+    {
+        return new AllSession();
+    }
+}

--- a/src/Factory/AllSessionRequestFactoryInterface.php
+++ b/src/Factory/AllSessionRequestFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusPayumStripePlugin\Factory;
+
+use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
+
+interface AllSessionRequestFactoryInterface
+{
+    public function createNew(): AllInterface;
+}

--- a/src/Factory/ExpireSessionRequestFactory.php
+++ b/src/Factory/ExpireSessionRequestFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusPayumStripePlugin\Factory;
+
+use FluxSE\PayumStripe\Request\Api\Resource\CustomCallInterface;
+use FluxSE\PayumStripe\Request\Api\Resource\ExpireSession;
+
+final class ExpireSessionRequestFactory implements ExpireSessionRequestFactoryInterface
+{
+    public function createNew(string $id): CustomCallInterface
+    {
+        return new ExpireSession($id);
+    }
+}

--- a/src/Factory/ExpireSessionRequestFactoryInterface.php
+++ b/src/Factory/ExpireSessionRequestFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusPayumStripePlugin\Factory;
+
+use FluxSE\PayumStripe\Request\Api\Resource\CustomCallInterface;
+
+interface ExpireSessionRequestFactoryInterface
+{
+    public function createNew(string $id): CustomCallInterface;
+}

--- a/src/Resources/config/services/factory.yaml
+++ b/src/Resources/config/services/factory.yaml
@@ -11,3 +11,9 @@ services:
 
   flux_se.sylius_payum_stripe.factory.cancel_payment_intent_request:
     class: FluxSE\SyliusPayumStripePlugin\Factory\CancelPaymentIntentRequestFactory
+
+  flux_se.sylius_payum_stripe.factory.all_session_request:
+    class: FluxSE\SyliusPayumStripePlugin\Factory\AllSessionRequestFactory
+
+  flux_se.sylius_payum_stripe.factory.expire_session_request:
+    class: FluxSE\SyliusPayumStripePlugin\Factory\ExpireSessionRequestFactory

--- a/src/Resources/config/services/payum.yaml
+++ b/src/Resources/config/services/payum.yaml
@@ -29,7 +29,8 @@ services:
     public: true
     class: FluxSE\SyliusPayumStripePlugin\Extension\CancelExistingPaymentIntentExtension
     arguments:
-      $cancelPaymentIntentRequestFactory: '@flux_se.sylius_payum_stripe.factory.cancel_payment_intent_request'
+      $expireSessionRequestFactory: '@flux_se.sylius_payum_stripe.factory.expire_session_request'
+      $allSessionRequestFactory: '@flux_se.sylius_payum_stripe.factory.all_session_request'
     tags:
       - name: payum.extension
         factory: stripe_checkout_session

--- a/tests/Behat/Resources/services/mocker.xml
+++ b/tests/Behat/Resources/services/mocker.xml
@@ -18,6 +18,16 @@
             <tag name="payum.action" factory="stripe_checkout_session" prepend="true" />
         </service>
 
+        <service id="tests.flux_se.sylius_payum_stripe_checkout_session_plugin.behat.mocker.action.all_session"
+                 class="FluxSE\PayumStripe\Action\Api\Resource\AllSessionAction" public="true">
+            <tag name="payum.action" factory="stripe_checkout_session" prepend="true" />
+        </service>
+
+        <service id="tests.flux_se.sylius_payum_stripe_checkout_session_plugin.behat.mocker.action.expire_session"
+                 class="FluxSE\PayumStripe\Action\Api\Resource\ExpireSessionAction" public="true">
+            <tag name="payum.action" factory="stripe_checkout_session" prepend="true" />
+        </service>
+
         <service id="tests.flux_se.sylius_payum_stripe_checkout_session_plugin.behat.mocker.stripe_session_checkout_mocker"
                  class="Tests\FluxSE\SyliusPayumStripePlugin\Behat\Mocker\StripeCheckoutSessionMocker">
             <argument type="service" id="sylius.behat.mocker"/>


### PR DESCRIPTION
https://stripe.com/docs/api/payment_intents/cancel

> You cannot cancel the PaymentIntent for a Checkout Session. Expire the Checkout Session instead