### PR TITLE
Fix bad indentation in French messages catalog.

### DIFF
--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -8,9 +8,9 @@ flux_se_sylius_payum_stripe_plugin:
                 secret_key: Clé secrète
                 use_authorize: Utiliser "authorize"
                 webhook_secret_keys: Clés secrètes du webhook
-            help:
-                use_authorize: >
-                    Lorsqu'un paiement est autorisé, la banque garantit le montant et le conserve sur la carte du client jusqu'à sept jours .
-                    <a href="https://stripe.com/docs/payments/capture-later" target="_blank">
-                        En savoir plus
-                    </a>
+                help:
+                    use_authorize: >
+                        Lorsqu'un paiement est autorisé, la banque garantit le montant et le conserve sur la carte du client jusqu'à sept jours.
+                        <a href="https://stripe.com/docs/payments/capture-later" target="_blank">
+                            En savoir plus
+                        </a>


### PR DESCRIPTION
Hello !

This PR is a simple fix for bad indented yaml in the French translation "messages" catalog, that produces a missing translation in the payment method form.

Without the fix (french locale) : 
![image](https://user-images.githubusercontent.com/11628056/195319115-d8c23216-07d4-4c50-b275-51ca919c44a3.png)

With the fix : 
![image](https://user-images.githubusercontent.com/11628056/195319002-8bce7692-e187-4f43-857f-fb871c0143c1.png)
