### PR TITLE
Fix #53 - cancel an empty payment

### DIFF
--- a/features/admin/cancel_authorized_order.feature
+++ b/features/admin/cancel_authorized_order.feature
@@ -16,7 +16,7 @@ Feature: Canceling an authorized order
     And I am logged in as an administrator
 
   @ui
-  Scenario: Initializing the Stripe refund
+  Scenario: Cancelling the order with an authorized payment
     Given I am viewing the summary of this order
     And I am prepared to cancel this order
     When I cancel this order

--- a/features/admin/cancel_order.feature
+++ b/features/admin/cancel_order.feature
@@ -23,3 +23,13 @@ Feature: Canceling an order
     Then I should be notified that it has been successfully updated
     And it should have payment with state cancelled
     And it should have payment state cancelled
+
+  @ui
+  Scenario: Cancelling the order after the customer go back during the payment
+    Given this order has a Stripe payment cancelled
+    And I am viewing the summary of this order
+    And I am prepared to cancel this order
+    When I cancel this order
+    Then I should be notified that it has been successfully updated
+    And it should have payment with state cancelled
+    And it should have payment state cancelled

--- a/features/admin/cancel_order.feature
+++ b/features/admin/cancel_order.feature
@@ -16,7 +16,7 @@ Feature: Canceling an order
     And I am logged in as an administrator
 
   @ui
-  Scenario: Initializing the Stripe refund
+  Scenario: Cancelling the order when a checkout session is still available
     Given I am viewing the summary of this order
     And I am prepared to expire the checkout session on this order
     When I cancel this order
@@ -25,8 +25,8 @@ Feature: Canceling an order
     And it should have payment state cancelled
 
   @ui
-  Scenario: Cancelling the order after the customer go back during the payment
-    Given this order has a Stripe payment cancelled
+  Scenario: Cancelling the order after the customer canceled the payment
+    Given this order payment has been canceled
     And I am viewing the summary of this order
     And I am prepared to cancel this order
     When I cancel this order

--- a/features/admin/cancel_order.feature
+++ b/features/admin/cancel_order.feature
@@ -18,7 +18,7 @@ Feature: Canceling an order
   @ui
   Scenario: Initializing the Stripe refund
     Given I am viewing the summary of this order
-    And I am prepared to expire the checkout session this order
+    And I am prepared to expire the checkout session on this order
     When I cancel this order
     Then I should be notified that it has been successfully updated
     And it should have payment with state cancelled

--- a/src/CommandHandler/CancelPaymentHandler.php
+++ b/src/CommandHandler/CancelPaymentHandler.php
@@ -35,7 +35,7 @@ final class CancelPaymentHandler extends AbstractPayumPaymentHandler
             return;
         }
 
-        if (empty($payment->getDetails())) {
+        if (0 === count($payment->getDetails())) {
             return;
         }
 

--- a/src/CommandHandler/CancelPaymentHandler.php
+++ b/src/CommandHandler/CancelPaymentHandler.php
@@ -35,6 +35,10 @@ final class CancelPaymentHandler extends AbstractPayumPaymentHandler
             return;
         }
 
+        if (empty($payment->getDetails())) {
+            return;
+        }
+
         $gatewayName = $this->getGatewayNameFromPayment($payment);
 
         if (null === $gatewayName) {

--- a/tests/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/tests/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -102,7 +102,7 @@ class ManagingOrdersContext implements Context
 
         $this->objectManager->flush();
     }
-    
+
     /**
      * @Given /^(this order) has a Stripe payment cancelled$/
      */
@@ -120,7 +120,7 @@ class ManagingOrdersContext implements Context
         $paymentReplaced->setAmount($payment->getAmount());
         $paymentReplaced->setCurrencyCode($payment->getCurrencyCode());
         $order->addPayment($paymentReplaced);
-        
+
         $this->objectManager->persist($order);
         $this->objectManager->flush();
     }
@@ -141,9 +141,9 @@ class ManagingOrdersContext implements Context
     }
 
     /**
-     * @Given I am prepared to expire the checkout session this order
+     * @Given I am prepared to expire the checkout session on this order
      */
-    public function iAmPreparedToExpireTheCheckoutSessionThisOrder(): void
+    public function iAmPreparedToExpireTheCheckoutSessionOnThisOrder(): void
     {
         $this->stripeSessionCheckoutMocker->mockExpirePayment();
     }

--- a/tests/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/tests/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -104,24 +104,17 @@ class ManagingOrdersContext implements Context
     }
 
     /**
-     * @Given /^(this order) has a Stripe payment cancelled$/
+     * @Given /^(this order) payment has been canceled$/
      */
-    public function thisOrderHasStripePaymentCancelled(OrderInterface $order): void
+    public function thisOrderPaymentHasBeenCancelled(OrderInterface $order): void
     {
         /** @var PaymentInterface $payment */
         $payment = $order->getPayments()->first();
-        $payment->setState(PaymentInterface::STATE_CANCELLED);
 
-        Assert::notNull($payment->getAmount());
-        Assert::notNull($payment->getCurrencyCode());
+        /** @var StateMachineInterface $stateMachine */
+        $stateMachine = $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH);
+        $stateMachine->apply(PaymentTransitions::TRANSITION_CANCEL);
 
-        $paymentReplaced = new Payment();
-        $paymentReplaced->setMethod($payment->getMethod());
-        $paymentReplaced->setAmount($payment->getAmount());
-        $paymentReplaced->setCurrencyCode($payment->getCurrencyCode());
-        $order->addPayment($paymentReplaced);
-
-        $this->objectManager->persist($order);
         $this->objectManager->flush();
     }
 


### PR DESCRIPTION
Hey :vulcan_salute: 

Explanations :
When an user cancel a payment (from stripe gateway), a void (i.e. no txid, or whatever (see `details` db field)) payment is created (normal behaviour from sylius) so when we want to cancel an order (from bo), all payments are intent to be cancel but void payment cannot be canceled to stripe side (it's void :), no txid exist ) 

so this pr aims to avoid error mentionned in #53 and focus on only cancel command

