### PR TITLE
Fix incorrect service reference in Stripe Checkout Session provider

### DIFF
--- a/src/Resources/config/services/stripe_checkout_session/api_platform.yaml
+++ b/src/Resources/config/services/stripe_checkout_session/api_platform.yaml
@@ -3,7 +3,7 @@ services:
   flux_se.sylius_payum_stripe.api.payment_provider.stripe_checkout_session:
     class: FluxSE\SyliusPayumStripePlugin\Api\PaymentConfiguration\StripeCheckoutSessionPaymentConfigProvider
     arguments:
-      $captureProcessor: '@flux_se.sylius_payum_stripe.api.payum.processor.stripe_js'
+      $captureProcessor: '@flux_se.sylius_payum_stripe.api.payum.processor.stripe_checkout_session'
       $factoryName: 'stripe_checkout_session'
     tags:
       - name: sylius.api.payment_method_handler


### PR DESCRIPTION
The `flux_se.sylius_payum_stripe.api.payment_provider.stripe_checkout_session` service was incorrectly using `@flux_se.sylius_payum_stripe.api.payum.processor.stripe_js` as the `$captureProcessor`.
This has been corrected to use `@flux_se.sylius_payum_stripe.api.payum.processor.stripe_checkout_session` instead.