### PR TITLE
Add a test to avoid re-creating a Checkout Session when there is already one

### DIFF
--- a/src/Action/ConvertPaymentAction.php
+++ b/src/Action/ConvertPaymentAction.php
@@ -27,6 +27,15 @@ final class ConvertPaymentAction implements ConvertPaymentActionInterface
 
         /** @var PaymentInterface $payment */
         $payment = $request->getSource();
+
+        $details = $payment->getDetails();
+
+        $id = $details['id'];
+        if (is_string($id) && $id !== '') {
+            $request->setResult($details);
+            return;
+        }
+
         /** @var OrderInterface $order */
         $order = $payment->getOrder();
 


### PR DESCRIPTION
This pull request introduces an early return in the `execute` method of `ConvertPaymentAction` to optimize processing when a payment already has a valid `id` in its details. This helps avoid unnecessary logic when the payment conversion has already occurred.

Logic optimization:

* Added a check for a non-empty string `id` in `$payment->getDetails`, and if present, the method sets the result and returns early, skipping further processing.